### PR TITLE
Simplify main.cpp and SharedProperty class

### DIFF
--- a/src/System/SharedProperty.h
+++ b/src/System/SharedProperty.h
@@ -25,31 +25,7 @@ class SharedProperty {
 			}
 		}
 
-		T operator=(T other) {
-			setValue(other);
-			return _value;
-		}
-
-		SharedProperty<T>& operator=(SharedProperty<T>& other) {
-			T val = other.getValue();
-			setValue(val);
-			return *this;
-		}
-
-		friend std::ostream& operator<<(std::ostream& os, SharedProperty<T>& property) {
-			os << property.getValue();
-			return os;
-		}
-
-		T operator<<(int32_t shift) {
-			return (T)(_value << shift);
-		}
-
-		T operator!() {
-			return !_value;
-		}
-
-		void setValue(T value) {
+		void set(T value) {
 			_stateMutex.lock();
 			if (value != _value) {
 				_value = value;
@@ -61,7 +37,7 @@ class SharedProperty {
 			}
 		}
 
-		T getValue() {
+		T value() {
 			_stateMutex.lock();
 			T ret = _value;
 			_stateMutex.unlock();


### PR DESCRIPTION
Thought it might be good to do a small refactoring to make this code a bit easier to read and understand.  In retrospect, I think overloading operators makes it harder to tell what type a variable is.

- changes object names so all instances of SharedProperty end with 'Val' (ex. ignitionVal) -- now all objects whose name ends in Val are of type SharedProperty
- removes overloaded operators from SharedProperty class
- changes names of SharedProperty::getValue() and SharedProperty::setValue() to SharedProperty::set() and SharedProperty::value()