### PR TITLE
Steering rpm/speed display + Eshift

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -45,7 +45,6 @@ storage/kvstore
 storage/platform
 
 platform/tests
-TEST_APPS
 TESTS
 UNITTESTS
 

--- a/src/Interface/SteeringDisplay.cpp
+++ b/src/Interface/SteeringDisplay.cpp
@@ -8,6 +8,7 @@
 #include "graphics.h"
 
 /* Display Macros */
+// #define DISPLAY_RPM
 
 // fonts
 #define SMALL_FONT Arial12x12
@@ -147,8 +148,10 @@ void SteeringDisplay::init() {
     _tft->printf("PWR");
     _tft->locate(TIME_X_LABEL, TIME_Y_LABEL);
     _tft->printf("TIME");
-    // _tft->locate(RPM_X_LABEL, RPM_Y_LABEL);
-    // _tft->printf("RPM");
+    #ifdef DISPLAY_RPM
+    _tft->locate(RPM_X_LABEL, RPM_Y_LABEL);
+    _tft->printf("RPM");
+    #endif
 
     /* Cool Font Graphics */
     _tft->set_font((unsigned char*)COOL_FONT);
@@ -164,9 +167,11 @@ void SteeringDisplay::init() {
     _initializeDynamicText(&_powerText, SteeringDisplay::Power, POWER_X, POWER_Y, (unsigned char*)COOL_FONT, "000");
 
     // Rpm
+    #ifdef DISPLAY_RPM
     // _tft->locate(RPM_X + RPM_X_UNIT_OFFSET, RPM_Y);
     // _tft->printf("RPM");
     // _initializeDynamicText(&_rpmText, SteeringDisplay::Rpm, RPM_X, RPM_Y, (unsigned char*)COOL_FONT, "0000");
+    #endif
 
     // EShift
     _tft->rect(ESHIFT_BOX_X, ESHIFT_BOX_Y, ESHIFT_BOX_X + ESHIFT_BOX_X_WIDTH, ESHIFT_BOX_Y + ESHIFT_BOX_Y_HEIGHT, White);

--- a/src/Interface/SteeringDisplay.cpp
+++ b/src/Interface/SteeringDisplay.cpp
@@ -41,34 +41,34 @@
 #define BATTERY_BTN_WIDTH 2
 #define BATTERY_BTN_HEIGHT 10
 
+// rpm
+#define RPM_X_LABEL 15
+#define RPM_Y_LABEL 103
+#define RPM_X 50
+#define RPM_X_UNIT_OFFSET 140
+#define RPM_Y 85
+
 // speed
 #define SPEED_X_LABEL 50
-#define SPEED_Y_LABEL 103
+#define SPEED_Y_LABEL 143
 #define SPEED_X 80
 #define SPEED_X_UNIT_OFFSET 110
-#define SPEED_Y 85
+#define SPEED_Y 125
 
 // power
 #define POWER_X_LABEL 48
-#define POWER_Y_LABEL 153
+#define POWER_Y_LABEL 183
 #define POWER_X 80
 #define POWER_X_UNIT_OFFSET 110
-#define POWER_Y 135
-
-// rpm
-#define RPM_X_LABEL 15
-#define RPM_Y_LABEL 63
-#define RPM_X 50
-#define RPM_X_UNIT_OFFSET 140
-#define RPM_Y 45
+#define POWER_Y 165
 
 // time
 #define TIME_X_LABEL 46
-#define TIME_Y_LABEL 203
+#define TIME_Y_LABEL 223
 #define MINUTES_X 80
 #define COLON_X 160
 #define SECONDS_X 185
-#define TIME_Y 185
+#define TIME_Y 205
 
 // throttle debug
 #define THROTTLE_RAW_X 10
@@ -78,19 +78,25 @@
 #define TURN_FLASHING_INTERVAL 500
 #define TURN_WIDTH 30
 #define TURN_HEIGHT 30
-#define TURN_LEFT_X 10
-#define TURN_LEFT_Y 150
-#define TURN_RIGHT_X 280
-#define TURN_RIGHT_Y 150
+#define TURN_LEFT_X 30
+#define TURN_LEFT_Y 50
+#define TURN_RIGHT_X 260
+#define TURN_RIGHT_Y 50
 
 // lights
 #define LIGHTS_X 140
-#define LIGHTS_Y 100
+#define LIGHTS_Y 48
 #define LIGHTS_WIDTH 40
 #define LIGHTS_HEIGHT 30
 
 // e-shift
-#define ESHIFT_Y STATUS_Y + 46
+#define ESHIFT_X 160
+#define ESHIFT_X_UNIT_OFFSET 30
+#define ESHIFT_Y 85
+#define ESHIFT_BOX_X 120
+#define ESHIFT_BOX_X_WIDTH 82
+#define ESHIFT_BOX_Y 83
+#define ESHIFT_BOX_Y_HEIGHT 40
 
 SteeringDisplay::SteeringDisplay(SPI_TFT_ILI9341* tft) : _tft(tft) {
     _animationTimer.start();
@@ -133,8 +139,6 @@ void SteeringDisplay::init() {
     _initializeDynamicText(&_batterySocText, SteeringDisplay::Soc, BATTERY_TEXT_X, SOC_TEXT_Y, (unsigned char*)SMALL_FONT, "00.0 %%");
     // Battery Voltage
     _initializeDynamicText(&_batteryVoltageText, SteeringDisplay::Voltage, BATTERY_TEXT_X, VOLTAGE_TEXT_Y, (unsigned char*)SMALL_FONT, "00.0 V");
-    // E-Shift Level
-    _initializeDynamicText(&_eShiftText, SteeringDisplay::eShift, BATTERY_TEXT_X, ESHIFT_Y, (unsigned char*)SMALL_FONT, "0 LVL");
 
     // Cool Font Graphics Labels
     _tft->locate(SPEED_X_LABEL, SPEED_Y_LABEL);
@@ -143,8 +147,8 @@ void SteeringDisplay::init() {
     _tft->printf("PWR");
     _tft->locate(TIME_X_LABEL, TIME_Y_LABEL);
     _tft->printf("TIME");
-    _tft->locate(RPM_X_LABEL, RPM_Y_LABEL);
-    _tft->printf("RPM");
+    // _tft->locate(RPM_X_LABEL, RPM_Y_LABEL);
+    // _tft->printf("RPM");
 
     /* Cool Font Graphics */
     _tft->set_font((unsigned char*)COOL_FONT);
@@ -160,9 +164,15 @@ void SteeringDisplay::init() {
     _initializeDynamicText(&_powerText, SteeringDisplay::Power, POWER_X, POWER_Y, (unsigned char*)COOL_FONT, "000");
 
     // Rpm
-    _tft->locate(RPM_X + RPM_X_UNIT_OFFSET, RPM_Y);
-    _tft->printf("RPM");
-    _initializeDynamicText(&_rpmText, SteeringDisplay::Rpm, RPM_X, RPM_Y, (unsigned char*)COOL_FONT, "0000");
+    // _tft->locate(RPM_X + RPM_X_UNIT_OFFSET, RPM_Y);
+    // _tft->printf("RPM");
+    // _initializeDynamicText(&_rpmText, SteeringDisplay::Rpm, RPM_X, RPM_Y, (unsigned char*)COOL_FONT, "0000");
+
+    // EShift
+    _tft->rect(ESHIFT_BOX_X, ESHIFT_BOX_Y, ESHIFT_BOX_X + ESHIFT_BOX_X_WIDTH, ESHIFT_BOX_Y + ESHIFT_BOX_Y_HEIGHT, White);
+    _tft->locate(ESHIFT_X - ESHIFT_X_UNIT_OFFSET, ESHIFT_Y);
+    _tft->printf("S");
+    _initializeDynamicText(&_eShiftText, SteeringDisplay::eShift, ESHIFT_X, ESHIFT_Y, (unsigned char*)COOL_FONT, "1");
 
     // Time
     _tft->locate(COLON_X, TIME_Y);
@@ -297,7 +307,7 @@ void SteeringDisplay::_onVoltageChanged(const batt_t value) {
 }
 
 void SteeringDisplay::_onEShiftChanged(const eshift_t value) {
-    char buf[1]={};
+    char buf[2]={};
     sprintf(buf,"%01u", value);
     _updateTextField(SteeringDisplay::eShift, std::string(buf));
 }

--- a/src/Interface/SteeringDisplay.h
+++ b/src/Interface/SteeringDisplay.h
@@ -26,7 +26,7 @@ using namespace util;
 
 class SteeringDisplay {
 	public:
-		enum DynamicGraphicId { Dms, Ignition, Brake, Battery, Soc, Voltage, Speed, Power, Lights, LeftSignal, RightSignal, Minutes, Seconds, Hazards };
+		enum DynamicGraphicId { Dms, Ignition, Brake, Battery, Soc, Voltage, eShift, Speed, Power, Rpm, Lights, LeftSignal, RightSignal, Minutes, Seconds, Hazards };
 		SteeringDisplay(SPI_TFT_ILI9341* tft);
 		~SteeringDisplay() { }
 		void init();
@@ -63,8 +63,10 @@ class SteeringDisplay {
 		ScalableRectangle _batteryIcon;
 		Text _batterySocText;
 		Text _batteryVoltageText;
+		Text _eShiftText;
 		Text _speedText;
 		Text _powerText;
+		Text _rpmText;
 		Text _timeTextMinutes;
 		Text _timeTextSeconds;
 		Bitmap _lights;
@@ -84,8 +86,10 @@ class SteeringDisplay {
 		void _onBrakeChanged(const data_t value);
 		void _onBatterySocChanged(const batt_t value);
 		void _onVoltageChanged(const batt_t value);
+		void _onEShiftChanged(const eshift_t value);
 		void _onSpeedChanged(const speed_t value);
 		void _onPowerChanged(const throttle_t value);
+		void _onRpmChanged(const rpm_t value);
 		void _onLightsChanged(const data_t value);
 		void _onLeftSignalChanged(const data_t value);
 		void _onRightSignalChanged(const data_t value);

--- a/src/Interface/data-types.h
+++ b/src/Interface/data-types.h
@@ -3,8 +3,10 @@
 /* macro for shared property type */
 #define batt_t float
 #define data_t char
+#define eshift_t unsigned
 #define speed_t unsigned
 #define throttle_t uint8_t
+#define rpm_t unsigned
 
 struct steering_time_t { 
 	int minutes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,11 +218,7 @@ void handle_motor_inputs(int &eshift, int &prev_state) {
         }
 
         if (prev_state == 0){
-            if(curr_state == 1){
-                eshift++;
-            } else if(curr_state == -1){
-                eshift--;
-            }
+            eshift += curr_state;
         }
         
         prev_state = curr_state;
@@ -316,10 +312,6 @@ void receive_can() {
     CANMessage msg;
 
     if (can.read(msg)) {
-        // if (msg.id == CAN_TELEMETRY_GPS_DATA) {
-        //     currentSpeedVal.set((speed_t)msg.data[0]);
-            
-        // } else 
         if(msg.id == CAN_MOTOR_RPM) {   
             // Reconstruct the integer value from the byte array
             int rpm =(msg.data[0] << 8) | msg.data[1];
@@ -334,7 +326,6 @@ void receive_can() {
             batt_t voltage = voltageData / CAN_BATT_VOLTAGE_SCALING_FACTOR;
             batteryVoltageVal.set(voltage);
         } 
-        
     }
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -11,9 +11,6 @@
 #define IGNITION_BUTTON 6
 #define HAZARDS_BUTTON 7
 
-#define ESHIFT_UP 8
-#define ESHIFT_DOWN 9
-
 //LED definitions
 #define WIPER_LED 1
 #define LIGHTS_LED 2

--- a/src/main.h
+++ b/src/main.h
@@ -11,6 +11,9 @@
 #define IGNITION_BUTTON 6
 #define HAZARDS_BUTTON 7
 
+#define ESHIFT_UP 8
+#define ESHIFT_DOWN 9
+
 //LED definitions
 #define WIPER_LED 1
 #define LIGHTS_LED 2
@@ -41,7 +44,7 @@ char read_accessory_inputs(char& hazardsVal);
  * to motor controller with throttle data, and another to telemetry indicating states of ignition, dms, etc..
  * 
  */
-void handle_motor_inputs();
+void handle_motor_inputs(int &eshift);
 
 /**
  * @brief Read dead man's switch

--- a/src/main.h
+++ b/src/main.h
@@ -44,7 +44,7 @@ char read_accessory_inputs(char& hazardsVal);
  * to motor controller with throttle data, and another to telemetry indicating states of ignition, dms, etc..
  * 
  */
-void handle_motor_inputs(int &eshift);
+void handle_motor_inputs(int &eshift,int &previous_x);
 
 /**
  * @brief Read dead man's switch


### PR DESCRIPTION
Implemented CAN transmission of motor rpm reading and e-shifting. Converts RPM value to speed and displays it on the monitor. Eshifting linearly maps throttle data to 5 levels, increasing until 100% of the throttle.